### PR TITLE
feat: `srcinfo.match_pkg`

### DIFF
--- a/src/srcinfo.sh
+++ b/src/srcinfo.sh
@@ -172,7 +172,7 @@ function srcinfo.parse() {
 
 function srcinfo.cleanup() {
     local var_prefix="${1:?No var_prefix passed to srcinfo.cleanup}" i z
-    local main_loop_template="${var_prefix}_access" comp
+    local main_loop_template="${var_prefix}_access" compg
     declare -n main_loop="${main_loop_template}"
     for i in "${main_loop[@]}"; do
         declare -n cleaner="${i}"
@@ -183,8 +183,8 @@ function srcinfo.cleanup() {
     done
     unset "${var_prefix}_access" globase global
     # So now lets clean the stragglers that we can't reasonably infer
-    mapfile -t comp < <(compgen -v)
-    for i in "${comp[@]}"; do
+    mapfile -t compg < <(compgen -v)
+    for i in "${compg[@]}"; do
         if [[ ${i} == "${var_prefix}_"* ]]; then
             unset -v "${i}"
         fi

--- a/src/srcinfo.sh
+++ b/src/srcinfo.sh
@@ -127,10 +127,6 @@ function srcinfo.parse() {
         temp_array="$(srcinfo._create_array "${locbase}" "${temp_line[key]}" "${var_prefix}")"
         declare -n ref="${temp_array}"
         ref+=("${temp_line[value]}")
-        #TODO: In the linux SRCINFO, the pkgbase pkgdesc and pkgname=linux pkgdesc
-        # get merged into an array, so I suppose we need to check if both pkgbase and
-        # pkgname have the same keys, and if so, use pkgname, and if not, inherit from
-        # pkgbase.
         if [[ ${locbase} == "pkgbase_"* ]] || ! srcinfo._contains total_list "${temp_array}"; then
             total_list+=("${temp_array}")
         fi

--- a/src/srcinfo.sh
+++ b/src/srcinfo.sh
@@ -291,7 +291,7 @@ function srcinfo.print_var() {
 # @arg $1 string .SRCINFO file path
 # @arg $2 string Variable or Array to search
 # @arg $3 string Package name or base to get output for
-srcinfo.match_pkg() {
+function srcinfo.match_pkg() {
     local declares d bases b guy match out srcfile="${1}" search="${2}" pkg="${3}"
     if [[ ${pkg} == "pkgbase:"* || ${search} == "pkgbase" ]]; then
         pkg="${pkg/pkgbase:/}"

--- a/src/srcinfo.sh
+++ b/src/srcinfo.sh
@@ -318,16 +318,16 @@ function srcinfo.match_pkg() {
                 if [[ -n ${pkgbase} ]]; then
                     out="${pkgbase/\"/}"
                     out="${out/\"/}"
-                    echo "pkgbase:${out}"
+                    printf '%s\n' "pkgbase:${out}"
                     continue
                 fi
-                echo "${!guy}"
+                printf '%s\n' "${!guy}"
                 continue
             else
-                echo "${guy}"
+                printf '%s\n' "${guy}"
                 continue
             fi
         fi
-        [[ ${b} == "${match}" ]] && echo "${!guy}"
+        [[ ${b} == "${match}" ]] && printf '%s\n' "${!guy}"
     done
 }

--- a/src/srcinfo.sh
+++ b/src/srcinfo.sh
@@ -176,7 +176,7 @@ function srcinfo.parse() {
 
 function srcinfo.cleanup() {
     local var_prefix="${1:?No var_prefix passed to srcinfo.cleanup}" i z
-    local main_loop_template="${var_prefix}_access"
+    local main_loop_template="${var_prefix}_access" comp
     declare -n main_loop="${main_loop_template}"
     for i in "${main_loop[@]}"; do
         declare -n cleaner="${i}"
@@ -187,11 +187,10 @@ function srcinfo.cleanup() {
     done
     unset "${var_prefix}_access" globase global
     # So now lets clean the stragglers that we can't reasonably infer
-    for i in $(compgen -v); do
-        if [[ ${i} == "${var_prefix}_"* ]] && [[ ${i} == *"_array_"* ]]; then
+    mapfile -t comp < <(compgen -v)
+    for i in "${comp[@]}"; do
+        if [[ ${i} == "${var_prefix}_"* ]]; then
             unset -v "${i}"
-            # sanity check
-            unset -f "${i}"
         fi
     done
 }
@@ -280,5 +279,55 @@ function srcinfo.print_var() {
             declare -p "${e%\[*}"
         fi
         unset "${e%\[*}"
+    done
+}
+
+# @description Output a specific variable from .SRCINFO
+#
+# @example
+#
+#   srcinfo.match_pkg .SRCINFO pkgbase
+#   srcinfo.match_pkg .SRCINFO pkgdesc $(srcinfo.match_pkg .SRCINFO pkgbase)
+# @arg $1 string .SRCINFO file path
+# @arg $2 string Variable or Array to search
+# @arg $3 string Package name or base to get output for
+srcinfo.match_pkg() {
+    local declares d bases b guy match out srcfile="${1}" search="${2}" pkg="${3}"
+    if [[ ${pkg} == "pkgbase:"* || ${search} == "pkgbase" ]]; then
+        pkg="${pkg/pkgbase:/}"
+        match="srcinfo_${search}_${pkg//-/_}_pkgbase"
+    else
+        match="srcinfo_${search}_${pkg//-/_}"
+    fi
+    mapfile -t declares < <(srcinfo.print_var "${srcfile}" "${search}" | awk '{sub(/^declare -a |^declare -- /, ""); print}')
+    [[ ${search} == "pkgbase" && -z ${declares[*]} ]] \
+        && mapfile -t declares < <(srcinfo.print_var "${srcfile}" "pkgname" | awk '{sub(/^declare -a |^declare -- /, ""); print}')
+    for d in "${declares[@]}"; do
+        if [[ "${d%=\(*}" =~ = ]]; then
+            declare -- "${d}"
+            bases+=("${d%=*}")
+        else
+            declare -a "${d}"
+            bases+=("${d%=\(*}")
+        fi
+    done
+    for b in "${bases[@]}"; do
+        guy="${b}[@]"
+        if [[ -z "${pkg}" ]]; then
+            if [[ ${search} == "pkgname" ]] || ((${#bases[@]}==1)); then
+                if [[ ${search} == "pkgbase" && -n ${pkgbase} ]]; then
+                    out="${pkgbase/\"/}"
+                    out="${out/\"/}"
+                    echo "pkgbase:${out}"
+                    continue
+                fi
+                echo "${!guy}"
+                continue
+            else
+                echo "${guy}"
+                continue
+            fi
+        fi
+        [[ ${b} == "${match}" ]] && echo "${!guy}"
     done
 }

--- a/src/srcinfo.sh
+++ b/src/srcinfo.sh
@@ -314,7 +314,7 @@ srcinfo.match_pkg() {
     for b in "${bases[@]}"; do
         guy="${b}[@]"
         if [[ -z "${pkg}" ]]; then
-            if [[ ${search} == "pkgname" ]] || ((${#bases[@]}==1)); then
+            if [[ ${search} == "pkgname" ]]; then
                 if [[ ${search} == "pkgbase" && -n ${pkgbase} ]]; then
                     out="${pkgbase/\"/}"
                     out="${out/\"/}"

--- a/src/srcinfo.sh
+++ b/src/srcinfo.sh
@@ -84,6 +84,7 @@ function srcinfo._promote_to_variable() {
 
 function srcinfo.parse() {
     # We need this for trimming whitespace without external tools.
+    # shellcheck disable=SC2064
     trap "$(shopt -p extglob)" RETURN
     shopt -s extglob
     local srcinfo_file var_prefix locbase temp_array ref total_list loop part i part_two split_up

--- a/src/srcinfo.sh
+++ b/src/srcinfo.sh
@@ -84,6 +84,7 @@ function srcinfo._promote_to_variable() {
 
 function srcinfo.parse() {
     # We need this for trimming whitespace without external tools.
+    trap "$(shopt -p extglob)" RETURN
     shopt -s extglob
     local srcinfo_file var_prefix locbase temp_array ref total_list loop part i part_two split_up
     srcinfo_file="${1:?No .SRCINFO passed to srcinfo.parse}"
@@ -135,7 +136,7 @@ function srcinfo.parse() {
     for loop in "${total_list[@]}"; do
         declare -n part="${loop}"
         # Are we at a new pkgname (pkgbase)?
-        if [[ ${loop} == *"pkgname" || ${loop} == *"pkgbase" ]]; then
+        if [[ ${loop} == *@(pkgname|pkgbase) ]]; then
             declare -n var_name="${var_prefix}_access"
             [[ ${loop} == "${var_prefix}_pkgbase"* ]] && global="pkgbase_"
             for i in "${!part[@]}"; do

--- a/src/srcinfo.sh
+++ b/src/srcinfo.sh
@@ -281,9 +281,9 @@ function srcinfo.print_var() {
 # @description Output a specific variable from .SRCINFO
 #
 # @example
-#
 #   srcinfo.match_pkg .SRCINFO pkgbase
 #   srcinfo.match_pkg .SRCINFO pkgdesc $(srcinfo.match_pkg .SRCINFO pkgbase)
+#
 # @arg $1 string .SRCINFO file path
 # @arg $2 string Variable or Array to search
 # @arg $3 string Package name or base to get output for

--- a/src/srcinfo.sh
+++ b/src/srcinfo.sh
@@ -314,8 +314,8 @@ srcinfo.match_pkg() {
     for b in "${bases[@]}"; do
         guy="${b}[@]"
         if [[ -z "${pkg}" ]]; then
-            if [[ ${search} == "pkgname" ]]; then
-                if [[ ${search} == "pkgbase" && -n ${pkgbase} ]]; then
+            if [[ ${search} == "pkgname" || ${search} == "pkgbase" ]]; then
+                if [[ -n ${pkgbase} ]]; then
                     out="${pkgbase/\"/}"
                     out="${out/\"/}"
                     echo "pkgbase:${out}"

--- a/src/srcinfo.sh
+++ b/src/srcinfo.sh
@@ -200,7 +200,7 @@ function srcinfo.cleanup() {
 #   converts to `srcinfo_depends_vala_panel_appmenu_valapanel_git=([0]="gtk3")`
 #
 # @arg $1 string Associative array to reformat
-# @arg $2 string Name of indexed array to append to append conversion to (can be anything)
+# @arg $2 string Ref string of indexed array to append conversion to (can be anything)
 function srcinfo.reformat_assarr() {
     local pfx base ida new pfs in_name="${1}"
     local -n in_arr="${in_name}" app="${2}"


### PR DESCRIPTION
has 3 inputs
`srcfile="${1}" search="${2}" pkg="${3}"`
`pkg` is optional

if `pkg` is not provided, then the result looks like:
```bash
rhino@docker-desktop:~$ srcinfo.match_pkg pacstall-qa-git.SRCINFO pkgdesc
srcinfo_pkgdesc_pacstall_qa_git[@]


rhino@docker-desktop:~$ srcinfo.match_pkg SRCINFO pkgdesc
srcinfo_pkgdesc_vala_panel_appmenu_xfce_git[@]
srcinfo_pkgdesc_vala_panel_appmenu_budgie_git[@]
srcinfo_pkgdesc_vala_panel_appmenu_mate_git[@]
srcinfo_pkgdesc_vala_panel_appmenu_xfce_git_pkgbase[@]
srcinfo_pkgdesc_vala_panel_appmenu_valapanel_git[@]
srcinfo_pkgdesc_vala_panel_appmenu_common_git[@]
```
The exceptions to this rule are:
1. `pkgname`
```bash
rhino@docker-desktop:~$ srcinfo.match_pkg SRCINFO pkgname    
vala-panel-appmenu-xfce-git
vala-panel-appmenu-budgie-git
vala-panel-appmenu-mate-git
vala-panel-appmenu-valapanel-git
vala-panel-appmenu-common-git
```
2. `pkgbase`
```bash
rhino@docker-desktop:~$ srcinfo.match_pkg SRCINFO pkgbase
pkgbase:vala-panel-appmenu-xfce-git
```
- evidently, the `pkgbase:` extension is how we distinguish from a pkgname for searching (see below)
- if there is no pkgbase present, then we get `pkgname` back
```bash
rhino@docker-desktop:~$ srcinfo.match_pkg pacstall-qa-git.SRCINFO pkgbase
pacstall-qa-git
```

Now, we can combine the results we just got for searching:
```bash
rhino@docker-desktop:~$ srcinfo.match_pkg pacstall-qa-git.SRCINFO gives $(srcinfo.match_pkg pacstall-qa-git.SRCINFO pkgbase)
pacstall-qa

rhino@docker-desktop:~$ srcinfo.match_pkg SRCINFO pkgdesc $(srcinfo.match_pkg SRCINFO pkgbase)
AppMenu (Global Menu) plugin


rhino@docker-desktop:~$ srcinfo.match_pkg pacstall-qa-git.SRCINFO pkgdesc $(srcinfo.match_pkg pacstall-qa-git.SRCINFO pkgbase)
A tool to easily test pacscripts from PRs locally


rhino@docker-desktop:~$ for i in $(srcinfo.match_pkg SRCINFO pkgname); do srcinfo.match_pkg SRCINFO pkgdesc ${i}; done
AppMenu (Global Menu) plugin for xfce4-panel
AppMenu (Global Menu) plugin for budgie-panel
AppMenu (Global Menu) plugin for mate-panel
AppMenu (Global Menu) plugin for vala-panel
Translations and common files for Global Menu


rhino@docker-desktop:~$ for i in $(srcinfo.match_pkg SRCINFO pkgname); do echo "${i}:"; for j in $(srcinfo.match_pkg SRCINFO depends ${i}); do printf '  %s\n' "${j}"; done; done
vala-panel-appmenu-xfce-git:
  gtk3
  xfce4-panel>=4.11.2
  xfconf
  libwnck3
  vala-panel-appmenu-common-git
  appmenu-glib-translator
vala-panel-appmenu-budgie-git:
  gtk3
  budgie-desktop
  libwnck3
  vala-panel-appmenu-common-git
  appmenu-glib-translator
vala-panel-appmenu-mate-git:
  gtk3
  mate-panel
  libwnck3
  vala-panel-appmenu-common-git
  appmenu-glib-translator
vala-panel-appmenu-valapanel-git:
  gtk3
  vala-panel
  libwnck3
  vala-panel-appmenu-common-git
  appmenu-glib-translator
vala-panel-appmenu-common-git:


rhino@docker-desktop:~$ mapfile -t srcs < <(srcinfo.match_pkg xdg-desktop-portal-hyprland.SRCINFO source $(srcinfo.match_pkg xdg-desktop-portal-hyprland.SRCINFO pkgname))
rhino@docker-desktop:~$ echo ${srcs[1]}
https://github.com/hyprwm/hyprland-protocols/archive/4d29e48433270a2af06b8bc711ca1fe5109746cd.tar.gz
rhino@docker-desktop:~$ echo ${srcs[0]}
https://github.com/hyprwm/xdg-desktop-portal-hyprland/archive/v1.3.1/xdg-desktop-portal-hyprland-1.3.1.tar.gz
```